### PR TITLE
Fix for overrideTunnelReturnTarget being Void

### DIFF
--- a/engine/Story.js
+++ b/engine/Story.js
@@ -636,6 +636,8 @@ export class Story extends InkObject{
 					if (overrideTunnelReturnTarget instanceof DivertTargetValue === false) {
 						if (popped instanceof Void === false){
 							throw "Expected void if ->-> doesn't override target";
+						} else {
+							overrideTunnelReturnTarget = null;
 						}
 					}
 				}


### PR DESCRIPTION
Need to explicitly set overrideTunnelReturnTarget to null if its void as we're missing the cast that C# does