### PR TITLE
State copy should clone dictionaries

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -717,6 +717,15 @@ export class StoryState{
 
 		copy.previousContentObject = this.previousContentObject;
 		
+		copy._visitCounts = {};
+		for (var keyValue in this._visitCounts) {
+		      	copy._visitCounts[keyValue] = this._visitCounts[keyValue];
+		}
+		copy._turnIndices = {};
+		for (var keyValue in this._turnIndices) {
+			copy._turnIndices[keyValue] = this._turnIndices[keyValue];
+		}
+  		
 		copy._visitCounts = this._visitCounts;
 		copy._turnIndices = this._turnIndices;
 		copy._currentTurnIndex = this.currentTurnIndex;


### PR DESCRIPTION
When copying a state, the visitCounts and turnIndices objects need to be cloned, so that later changes don't change their entries. Otherwise, you get strange effects, such as with the following ink source:

-> bug
=== bug
    Removing this line resolves the issue.
    {not knot:  
         // Including a line here resolves the issue
        -> knot ->
    - else: 
        This content should NEVER be seen.
    }
    -> END
    
=== knot
    This content SHOULD be seen.
    -> END

Note there may be other members of the State object which need cloning as well, but my comparison with the c# suggested this is all that's needed?