### PR TITLE
Fix for ink functions called from game code

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -717,6 +717,8 @@ export class StoryState{
 
 		copy.previousContentObject = this.previousContentObject;
 		
+		copy._isExternalFunctionEvaluation = this._isExternalFunctionEvaluation;
+		
 		copy._visitCounts = {};
 		for (var keyValue in this._visitCounts) {
 		      	copy._visitCounts[keyValue] = this._visitCounts[keyValue];


### PR DESCRIPTION
The following ink source: 

=== function not_working() ===
    Text1.
    Text2.
    ~ return true

in conjunction with a call like 

story.EvaluateFunction("not_working");

from the javascript file running the game causes an error when the ~ return statement is encountered as it's unexpected.

Note the C# doesn't seem to copy this property explicitly, but it is correct and does the fix the issue.