### PR TITLE
Fixes to external function evaluation

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -631,6 +631,8 @@ export class StoryState{
 		// Create a new base call stack element.
 		this.callStack = new CallStack(funcContainer);
 		this.callStack.currentElement.type = PushPopType.Function;
+		
+		this._variablesState._callStack = this.callStack;
 
 		// By setting ourselves in external function evaluation mode,
 		// we're saying it's okay to end the flow without a Done or End,
@@ -673,6 +675,8 @@ export class StoryState{
 		this.callStack = this._originalCallstack;
 		this._originalCallstack = null;
 		this._originalEvaluationStackHeight = 0;
+		
+		this._variablesState._callStack = this.callStack;
 
 		if (returnedObj) {
 			if (returnedObj instanceof Void)


### PR DESCRIPTION
A couple of lines required to fix external function evaluation seem to have fallen out of the latest version. (However, you'd better check that they really did get missed by mistake rather than being taken out deliberately!) And apologies, but I don't have a decent test case -- if I run my local js ink project, I get the "expected" results with these fixes, but not without.