### PR TITLE
Bugfix: previous container list wasn't cleared

### DIFF
--- a/engine/Story.js
+++ b/engine/Story.js
@@ -446,7 +446,7 @@ export class Story extends InkObject{
 			return;
             
 		// First, find the previously open set of containers
-		if (this._prevContainerSet == null) this._prevContainerSet = [];
+		this._prevContainerSet = [];
 		if (previousContentObject) {
 //			Container prevAncestor = previousContentObject as Container ?? previousContentObject.parent as Container;
 			var prevAncestor = (previousContentObject instanceof Container) ? previousContentObject : previousContentObject.parent;


### PR DESCRIPTION
The equivalent c# for this section is 

// First, find the previously open set of containers
			if( _prevContainerSet == null ) _prevContainerSet = new HashSet<Container> ();
			_prevContainerSet.Clear();

...with the if'd statement being there to avoid multiple allocations, but the Clear() being called every time. The JS was missing this clear, resulting in previous containers hanging around.