### PR TITLE
Fix function declaration inside nested statement

### DIFF
--- a/engine/Story.js
+++ b/engine/Story.js
@@ -878,7 +878,7 @@ export class Story extends InkObject{
 
 				// Allow either int or a particular list item to be passed for the bounds,
 				// so wrap up a function to handle this casting for us.
-				function IntBound(obj){
+				var IntBound = function IntBound(obj){
 //					var listValue = obj as ListValue;
 					var listValue = obj;
 					if (listValue instanceof ListValue) {


### PR DESCRIPTION
This is an error in strict mode, which is forced by Babel.

```
SyntaxError: Strict mode does not allow function declarations in a lexically nested statement.
```