### PR TITLE
Ink 0.7.3

### DIFF
--- a/engine/ControlCommand.js
+++ b/engine/ControlCommand.js
@@ -50,6 +50,9 @@ export class ControlCommand extends InkObject{
 	static TurnsSince(){
 		return new ControlCommand(CommandType.TurnsSince);
 	}
+	static ReadCount(){
+		return new ControlCommand(CommandType.ReadCount);
+	}
 	static Random(){
 		return new ControlCommand(CommandType.Random);
 	}
@@ -102,6 +105,7 @@ var CommandType = {
 	End: 18,
 	ListFromInt: 19,
 	ListRange: 20,
+	ReadCount: 21
 }
 CommandType.TOTAL_VALUES = Object.keys(CommandType).length - 1;//-1 because NotSet shoudn't count
 ControlCommand.CommandType = CommandType;

--- a/engine/JsonSerialisation.js
+++ b/engine/JsonSerialisation.js
@@ -615,6 +615,7 @@ _controlCommandNames[ControlCommand.CommandType.EndString] = "/str";
 _controlCommandNames[ControlCommand.CommandType.NoOp] = "nop";
 _controlCommandNames[ControlCommand.CommandType.ChoiceCount] = "choiceCnt";
 _controlCommandNames[ControlCommand.CommandType.TurnsSince] = "turns";
+_controlCommandNames[ControlCommand.CommandType.ReadCount] = "readc";
 _controlCommandNames[ControlCommand.CommandType.Random] = "rnd";
 _controlCommandNames[ControlCommand.CommandType.SeedRandom] = "srnd";
 _controlCommandNames[ControlCommand.CommandType.VisitIndex] = "visit";

--- a/engine/NativeFunctionCall.js
+++ b/engine/NativeFunctionCall.js
@@ -298,7 +298,6 @@ export class NativeFunctionCall extends InkObject{
 			this.AddStringBinaryOp(this.NotEquals,(x, y) => {return !(x === y) ? 1 : 0});
 			
 			this.AddListBinaryOp(this.Add, 		 (x, y) => {return x.Union(y)});
-			this.AddListBinaryOp(this.And, 		 (x, y) => {return x.Union(y)});
 			this.AddListBinaryOp(this.Subtract,  (x, y) => {return x.Without(y)});
 			this.AddListBinaryOp(this.Has, 		 (x, y) => {return x.Contains(y) ? 1 : 0});
 			this.AddListBinaryOp(this.Hasnt, 	 (x, y) => {return x.Contains(y) ? 0 : 1});
@@ -310,6 +309,9 @@ export class NativeFunctionCall extends InkObject{
 			this.AddListBinaryOp(this.GreaterThanOrEquals, 	(x, y) => {return x.GreaterThanOrEquals(y) ? 1 : 0});
 			this.AddListBinaryOp(this.LessThanOrEquals, 	(x, y) => {return x.LessThanOrEquals(y) ? 1 : 0});
 			this.AddListBinaryOp(this.NotEquals, 			(x, y) => {return !x.Equals(y) ? 1 : 0});
+
+			this.AddListBinaryOp (this.And, 				(x, y) => {return x.Count > 0 && y.Count > 0 ? 1 : 0});
+            this.AddListBinaryOp (this.Or,  				(x, y) => {return x.Count > 0 || y.Count > 0 ? 1 : 0});
 			
 			this.AddListUnaryOp(this.Not, (x) => {return x.Count == 0 ? 1 : 0});
 

--- a/engine/Story.js
+++ b/engine/Story.js
@@ -765,9 +765,9 @@ export class Story extends InkObject{
 
 				var eitherCount; 
 				if (evalCommand.commandType == ControlCommand.CommandType.TurnsSince)
-					eitherCount = TurnsSinceForContainer(container);
+					eitherCount = this.TurnsSinceForContainer(container);
 				else
-					eitherCount = VisitCountForContainer(container);
+					eitherCount = this.VisitCountForContainer(container);
 
 				this.state.PushEvaluationStack(new IntValue(eitherCount));
 				break;

--- a/engine/Story.js
+++ b/engine/Story.js
@@ -31,7 +31,7 @@ export class Story extends InkObject{
 		
 		lists = lists || null;
 		
-		this.inkVersionCurrent = 16;
+		this.inkVersionCurrent = 17;
 		this.inkVersionMinimumCompatible = 16;
 		
 		this._variableObservers = null;
@@ -748,12 +748,13 @@ export class Story extends InkObject{
 				break;
 
 			case ControlCommand.CommandType.TurnsSince:
+			case ControlCommand.CommandType.ReadCount:
 				var target = this.state.PopEvaluationStack();
 				if( !(target instanceof DivertTargetValue) ) {
 					var extraNote = "";
 					if( target instanceof IntValue )
 						extraNote = ". Did you accidentally pass a read count ('knot_name') instead of a target ('-> knot_name')?";
-					this.Error("TURNS_SINCE expected a divert target (knot, stitch, label name), but saw "+target+extraNote);
+					this.Error("TURNS_SINCE / READ_COUNT expected a divert target (knot, stitch, label name), but saw "+target+extraNote);
 					break;
 				}
 
@@ -761,8 +762,14 @@ export class Story extends InkObject{
 				var divertTarget = target;
 //				var container = ContentAtPath (divertTarget.targetPath) as Container;
 				var container = this.ContentAtPath(divertTarget.targetPath);
-				var turnCount = this.TurnsSinceForContainer(container);
-				this.state.PushEvaluationStack(new IntValue(turnCount));
+
+				var eitherCount; 
+				if (evalCommand.commandType == ControlCommand.CommandType.TurnsSince)
+					eitherCount = TurnsSinceForContainer(container);
+				else
+					eitherCount = VisitCountForContainer(container);
+
+				this.state.PushEvaluationStack(new IntValue(eitherCount));
 				break;
 
 			case ControlCommand.CommandType.Random:

--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -773,5 +773,5 @@ export class StoryState{
 	}
 }
 
-StoryState.kInkSaveStateVersion = 6;
+StoryState.kInkSaveStateVersion = 7;
 StoryState.kMinCompatibleLoadVersion = 6;


### PR DESCRIPTION
Ink 0.7.3 adds two new (minor) run-times features:-
- The "READ_COUNT" function, for retrieving the read count from a stored divert target. 
- The ability to && and || two lists, which evaluates via normal boolean logic on the non-emptiness of the lists

This PR also ups the ink version and the save version numbers.