### PR TITLE
Fix: logic returned int not IntValue

### DIFF
--- a/engine/NativeFunctionCall.js
+++ b/engine/NativeFunctionCall.js
@@ -147,7 +147,7 @@ export class NativeFunctionCall extends InkObject{
 //			var op = _operationFuncs [ValueType.Int] as BinaryOp<int>;
 			var op = this._operationFuncs[ValueType.Int];
 			var result = op(v1.isTruthy ? 1 : 0, v2.isTruthy ? 1 : 0);
-			return parseInt(result);
+			return new IntValue (result);
 		}
 
 		// Normal (list • list) operation


### PR DESCRIPTION
This bug's been here for a while, but I think this code path wasn't being used (much?) until 0.7.3 introduced "normal" && and || for lists.