### PR TITLE
StoryState._originalCallstack needs to be copied

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -740,6 +740,7 @@ export class StoryState{
 		copy.variablesState.CopyFrom(this.variablesState);
 
 		copy.evaluationStack.push.apply(copy.evaluationStack, this.evaluationStack);
+        	copy._originalEvaluationStackHeight = this._originalEvaluationStackHeight;
 
 		if (this.divertedTargetObject != null)
 			copy.divertedTargetObject = this.divertedTargetObject;

--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -734,7 +734,7 @@ export class StoryState{
 		}
 
 		copy.callStack = new CallStack(this.callStack);
-		copy._originalCallstack = this._originalCallstack;
+		if (this._originalCallstack) { copy._originalCallstack = new CallStack(this._originalCallstack); }
 		
 		copy._variablesState = new VariablesState(copy.callStack, this.story.listDefinitions);
 		copy.variablesState.CopyFrom(this.variablesState);

--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -734,6 +734,7 @@ export class StoryState{
 		}
 
 		copy.callStack = new CallStack(this.callStack);
+		copy._originalCallstack = this._originalCallstack;
 		
 		copy._variablesState = new VariablesState(copy.callStack, this.story.listDefinitions);
 		copy.variablesState.CopyFrom(this.variablesState);


### PR DESCRIPTION
This is a bug that's only just appeared in our tests; I guess we're using an external function in a slightly more complex way than previously.