### PR TITLE
Correcting case of toJson to ToJson

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -770,7 +770,7 @@ export class StoryState{
 		return copy;
 	}
 	
-	toJson(indented){
+	ToJson(indented){
 		return JSON.stringify(this.jsonToken, null, (indented) ? 2 : 0);
 	}
 	LoadJson(jsonString){


### PR DESCRIPTION
The case of the ToJson function is wrong. It's different from the C# implementation of Ink and from their documentation.