### PR TITLE
Saving of InkList is not working correctly

### DIFF
--- a/engine/InkList.js
+++ b/engine/InkList.js
@@ -42,7 +42,7 @@ export class InkListItem{
 		if (this.originName != null)
 			originCode = this.originName.toString();
 		
-		return originCode + itemCode;
+		return originCode + "." + itemCode;
 	}
 }
 


### PR DESCRIPTION
If you look at get fullName(), there's supposed to be a "." between the origin and the item names. InkLists can't be loaded correctly back from JSON without the period. 

There are two toString() methods in this class, but I'm assuming that was intentional.