### PR TITLE
Unset the "in external evaluation" flag

### DIFF
--- a/engine/StoryState.js
+++ b/engine/StoryState.js
@@ -681,6 +681,9 @@ export class StoryState{
 		this._originalEvaluationStackHeight = 0;
 		
 		this._variablesState.callStack = this.callStack;
+		
+		// No longer in external function eval
+	        this._isExternalFunctionEvaluation = false; 
 
 		if (returnedObj) {
 			if (returnedObj instanceof Void)


### PR DESCRIPTION
On completion of an external function, unset the flag that tells the engine we're in an externally called function.