### PR TITLE
fix: correct typos and indentation on multiple files

### DIFF
--- a/engine/CallStack.js
+++ b/engine/CallStack.js
@@ -150,7 +150,7 @@ export class CallStack{
 
 		for (var t = 0; t < this._threads.length; t++) {
 			var thread = this._threads[t];
-			var isCurrent = (t == _threads.length - 1);
+			var isCurrent = (t == this._threads.length - 1);
 			sb.AppendFormat("=== THREAD {0}/{1} {2}===\n", (t+1), this._threads.length, (isCurrent ? "(current) ":""));
 
 			for (var i = 0; i < thread.callstack.length; i++) {
@@ -160,18 +160,11 @@ export class CallStack{
 				else
 					sb.Append("  [TUNNEL] ");
 
-				var obj = thread.callstack[i].currentObject;
-				if (obj == null) {
-					if (thread.callstack[i].currentContainer != null) {
+				var pointer = thread.callstack[i].currentPointer;
+				if(!pointer.isNull) {
 					sb.Append("<SOMEWHERE IN ");
-					sb.Append(thread.callstack[i].currentContainer.path.ToString());
+					sb.Append(pointer.container.path.toString());
 					sb.AppendLine(">");
-					} else {
-					sb.AppendLine("<UNKNOWN STACK ELEMENT>");
-					}
-				} else {
-					var elementStr = obj.path.ToString();
-					sb.AppendLine(elementStr);
 				}
 			}
 		}
@@ -186,7 +179,7 @@ export class CallStack{
 	}
 	get currentElement(){
 		var thread = this._threads[this._threads.length - 1];
-		var cs = thread.callStack;
+		var cs = thread.callstack;
 		return cs[cs.length - 1];
 	}
 	get currentElementIndex(){
@@ -232,7 +225,7 @@ export class CallStack{
 		element.evaluationStackHeightWhenPushed = externalEvaluationStackHeight;
 		element.functionStartInOuputStream = outputStreamLengthWithPushed;
 
-		this.callStack.Add (element);
+		this.callStack.push (element);
 	}
 	PushThread(){
 		var newThread = this.currentThread.Copy();

--- a/engine/Choice.js
+++ b/engine/Choice.js
@@ -6,14 +6,14 @@ export class Choice{
 		this.index;
 		this.choicePoint;
 		this.threadAtGeneration;
-    this.sourcePath;
-    this.targetPath;
-    this.isInvisibleDefault = false;
-		
+		this.sourcePath;
+		this.targetPath;
+		this.isInvisibleDefault = false;
+
 		this._originalThreadIndex;
 	}
 	get pathStringOnChoice(){
-		return this.targetPath.ToString();
+		return this.targetPath.toString();
 	}
   set pathStringOnChoice(value){
 		this.targetPath = new Path(value);

--- a/engine/Container.js
+++ b/engine/Container.js
@@ -146,7 +146,7 @@ export class Container extends InkObject{//also implements INamedContent. Not su
 	}
 	ContentAtPath(path, partialPathStart, partialPathLength){
 		partialPathStart = (typeof partialPathStart !== 'undefined') ? partialPathStart : 0;
-		partialPathLength = (typeof partialPathLength !== 'undefined') ? partialPathLength : path.componentCount;
+		partialPathLength = (typeof partialPathLength !== 'undefined') ? partialPathLength : path.length;
 
 		var result = new SearchResult();
 		result.approximate = false;
@@ -156,7 +156,7 @@ export class Container extends InkObject{//also implements INamedContent. Not su
 
 		for (var i = partialPathStart; i < partialPathLength; ++i) {
 			var comp = path.GetComponent(i);
-			if (currentContainer == null || !(currentContainer instanceof Container)) {
+			if (currentContainer == null) {
 				result.approximate = true;
 				break;
 			}
@@ -170,7 +170,7 @@ export class Container extends InkObject{//also implements INamedContent. Not su
 
 			currentObj = foundObj
 //			currentContainer = currentObj as Container;
-			currentContainer = currentObj;
+			currentContainer = (foundObj instanceof Container) ? currentObj : null;
 		}
 
 		result.obj = currentObj;

--- a/engine/Divert.js
+++ b/engine/Divert.js
@@ -3,6 +3,7 @@ import {PushPopType} from './PushPop';
 import {StringBuilder} from './StringBuilder';
 import {Object as InkObject} from './Object';
 import {Pointer} from './Pointer';
+import {Container} from './Container';
 
 export class Divert extends InkObject{
 	constructor(stackPushType){
@@ -45,10 +46,10 @@ export class Divert extends InkObject{
 			var targetObj = this.ResolvePath(this._targetPath).obj;
 
 			if (this._targetPath.lastComponent.isIndex) {
-				this._targetPointer.container = targetObj.parent;
+				this._targetPointer.container = (targetObj.parent instanceof Container) ? targetObj.parent : null;
 				this._targetPointer.index = this._targetPath.lastComponent.index;
 			} else {
-				this._targetPointer = Pointer.StartOf(targetObj);
+				this._targetPointer = Pointer.StartOf((targetObj instanceof Container) ? targetObj : null);
 			}
 		}
 

--- a/engine/JsonSerialisation.js
+++ b/engine/JsonSerialisation.js
@@ -1,6 +1,6 @@
 import {Container} from './Container';
 import {Value, IntValue, FloatValue, StringValue, DivertTargetValue, VariablePointerValue, ListValue} from './Value';
-import {Glue, GlueType} from './Glue';
+import {Glue} from './Glue';
 import {ControlCommand} from './ControlCommand';
 import {PushPopType} from './PushPop';
 import {Divert} from './Divert';
@@ -28,15 +28,15 @@ export class JsonSerialisation{
 	static JArrayToRuntimeObjList(jArray, skipLast){
 		var count = jArray.length;
 		if (skipLast) count--;
-		
+
 		var list = [];
-		
+
 		for (var i = 0; i < count; i++){
 			var jTok = jArray[i];
 			var runtimeObj = this.JTokenToRuntimeObject(jTok);
 			list.push(runtimeObj);
 		}
-		
+
 		return list;
 	}
 	static JObjectToDictionaryRuntimeObjs(jObject){
@@ -79,7 +79,7 @@ export class JsonSerialisation{
 		if (!isNaN(token) && token !== "\n"){//JS thinks "\n" is a number
 			return Value.Create(token);
 		}
-		
+
 		if (typeof token === 'string'){
 			var str = token.toString();
 
@@ -116,7 +116,7 @@ export class JsonSerialisation{
 			if (str == "void")
 				return new Void ();
 		}
-		
+
 		if (typeof token === 'object' && token instanceof Array === false){
 			var obj = token;
 			var propValue;
@@ -126,7 +126,7 @@ export class JsonSerialisation{
 				propValue = obj["^->"];
 				return new DivertTargetValue(new Path(propValue.toString()));
 			}
-				
+
 			// VariablePointerValue
 			if (obj["^var"]) {
 				propValue = obj["^var"];
@@ -162,7 +162,7 @@ export class JsonSerialisation{
 				pushesToStack = false;
 				divPushType = PushPopType.Function;
 			}
-			
+
 			if (isDivert) {
 				var divert = new Divert();
 				divert.pushesToStack = pushesToStack;
@@ -175,7 +175,7 @@ export class JsonSerialisation{
 					divert.variableDivertName = target;
 				else
 					divert.targetPathString = target;
-				
+
 				divert.isConditional = !!obj["c"];
 
 				if (external) {
@@ -238,29 +238,29 @@ export class JsonSerialisation{
 //					rawList.SetInitialOriginNames(namesAsObjs.Cast<string>().ToList());
 					rawList.SetInitialOriginNames(namesAsObjs);
 				}
-				
+
 				for (var key in listContent){
 					var nameToVal = listContent[key];
 					var item = new InkListItem(key);
 					var val = parseInt(nameToVal);
 					rawList.Add(item, val);
 				}
-				
+
 				return new ListValue(rawList);
 			}
 
 			if (obj["originalChoicePath"] != null)
 				return this.JObjectToChoice(obj);
 		}
-		
+
 		// Array is always a Runtime.Container
 		if (token instanceof Array){
 			return this.JArrayToContainer(token);
 		}
-		
+
 		if (token == null)
                 return null;
-		
+
 		throw "Failed to convert token to runtime object: " + JSON.stringify(token);
 	}
 	static RuntimeObjectToJToken(obj){
@@ -294,7 +294,7 @@ export class JsonSerialisation{
 
 			if (divert.hasVariableTarget)
 				jObj["var"] = true;
-			
+
 			if (divert.isConditional)
 				jObj["c"] = true;
 
@@ -331,7 +331,7 @@ export class JsonSerialisation{
 			else
 				return "^" + strVal.value;
 		}
-		
+
 //		var listVal = obj as ListValue;
 		var listVal = obj;
 		if (listVal instanceof ListValue) {
@@ -407,7 +407,7 @@ export class JsonSerialisation{
 		var voidObj = obj;
 		if (voidObj instanceof Void)
 			return "void";
-	
+
 //		var tag = obj as Tag;
 		var tag = obj;
 		if (tag instanceof Tag) {
@@ -465,7 +465,7 @@ export class JsonSerialisation{
 				terminatingObj["#n"] = container.name;
 
 			jArray.push(terminatingObj);
-		} 
+		}
 
 		// Add null terminator to indicate that there's no dictionary
 		else {
@@ -487,7 +487,7 @@ export class JsonSerialisation{
 		if (terminatingObj != null) {
 
 			var namedOnlyContent = {};
-			
+
 			for (var key in terminatingObj){
 				if (key == "#f") {
 					container.countFlags = parseInt(terminatingObj[key]);
@@ -532,7 +532,7 @@ export class JsonSerialisation{
 		var dict = {};
 
 		var content = {};
-		
+
 		rawList.forEach(function(itemAndValue){
 			var item = itemAndValue.Key;
 			var val = itemAndValue.Value;
@@ -550,7 +550,7 @@ export class JsonSerialisation{
 	}
 	static ListDefinitionsToJToken(origin){
 		var result = {};
-		
+
 		origin.lists.forEach(function(def){
 			var listDefJson = {};
 			def.items.forEach(function(itemToVal){
@@ -558,10 +558,10 @@ export class JsonSerialisation{
 				var val = itemToVal.Value;
 				listDefJson[item.itemName] = val;
 			});
-			
+
 			result[def.name] = listDefJson;
 		});
-		
+
 		return result;
 	}
 	static JTokenToListDefinitions(obj){
@@ -569,7 +569,7 @@ export class JsonSerialisation{
 		var defsObj = obj;
 
 		var allDefs = [];
-		
+
 		for (var key in defsObj){
 			var name = key.toString();
 //			var listDefJson = (Dictionary<string, object>)kv.Value;
@@ -577,7 +577,7 @@ export class JsonSerialisation{
 
 			// Cast (string, object) to (string, int) for items
 			var items = {};
-			
+
 			for (var nameValueKey in listDefJson){
 				var nameValue = listDefJson[nameValueKey];
 				items[nameValueKey] = parseInt(nameValue);

--- a/engine/Object.js
+++ b/engine/Object.js
@@ -49,21 +49,21 @@ export class Object{
 		}
 		return ancestor;
 	}
-	
+
 	ResolvePath(path){
 		if (path.isRelative) {
 			var nearestContainer = this;
 
 			if (nearestContainer instanceof Container === false) {
 				if (this.parent == null) console.warn("Can't resolve relative path because we don't have a parent");
-				
+
 				nearestContainer = this.parent;
 				if (nearestContainer.constructor.name !== 'Container') console.warn("Expected parent to be a container");
-				
+
 				//Debug.Assert (path.GetComponent(0).isParent);
 				path = path.tail;
 			}
-			
+
 			return nearestContainer.ContentAtPath(path);
 		} else {
 			return this.rootContentContainer.ContentAtPath(path);
@@ -106,22 +106,22 @@ export class Object{
 	CompactPathString(otherPath){
 		var globalPathStr = null;
 		var relativePathStr = null;
-		
+
 		if (otherPath.isRelative) {
 			relativePathStr = otherPath.componentsString;
 			globalPathStr = this.path.PathByAppendingPath(otherPath).componentsString;
-		} 
+		}
 		else {
 			var relativePath = this.ConvertPathToRelative(otherPath);
 			relativePathStr = relativePath.componentsString;
 			globalPathStr = otherPath.componentsString;
 		}
 
-		if (relativePathStr.Length < globalPathStr.Length) 
+		if (relativePathStr.length < globalPathStr.length)
 			return relativePathStr;
 		else
 			return globalPathStr;
-	}	
+	}
 	Copy(){
 		throw "Not Implemented";
 	}

--- a/engine/Path.js
+++ b/engine/Path.js
@@ -3,7 +3,7 @@ export class Path{
 		this._isRelative;
 		this._components = [];
     this._componentsString = null;
-		
+
 		if (typeof arguments[0] == 'string'){
 			this.componentsString = arguments[0];
 		}
@@ -62,7 +62,7 @@ export class Path{
 		path._isRelative = true;
 		return path;
 	}
-	
+
   GetComponent(index){
     return this._components[index];
   }
@@ -93,14 +93,14 @@ export class Path{
       this._componentsString = this._components.join(".");
       if (this.isRelative) this._componentsString = "." + this._componentsString;
     }
-		
+
     return this._componentsString;
 	}
 	set componentsString(value){
 		this._components.length = 0;
 
 		this._componentsString = value;
-		
+
 		if (this._componentsString == null || this._componentsString == '') return;
 
 		// When components start with ".", it indicates a relative path, e.g.
@@ -137,7 +137,7 @@ export class Path{
 
 		if (otherPath.isRelative != this.isRelative)
 			return false;
-		
+
 		//the original code uses SequenceEqual here, so we need to iterate over the components manually.
 		for (var i = 0, l = otherPath._components.length; i < l; i++){
 			//it's not quite clear whether this test should use Equals or a simple == operator, see https://github.com/y-lohse/inkjs/issues/22
@@ -146,12 +146,12 @@ export class Path{
 
 		return true;
 	}
-  PathByAppendingComponent (c) {
-    var p = new Path();
-    p._components.AddRange(this._components);
-    p._components.Add(c);
-    return p;
-  }
+	PathByAppendingComponent (c) {
+		var p = new Path();
+		p._components.push.apply(p._components, this._components);
+		p._components.push(c);
+		return p;
+	}
 }
 
 class Component{
@@ -177,7 +177,7 @@ class Component{
 	get isParent(){
 		return this.name == Path.parentId;
 	}
-	
+
 	static ToParent(){
 		return new Component(Path.parentId);
 	}
@@ -191,7 +191,7 @@ class Component{
 	Equals(otherComp){
 		if (otherComp != null && otherComp.isIndex == this.isIndex) {
 			if (this.isIndex) {
-				return this.index == otherComp.index;   
+				return this.index == otherComp.index;
 			} else {
 				return this.name == otherComp.name;
 			}

--- a/engine/Pointer.js
+++ b/engine/Pointer.js
@@ -1,4 +1,4 @@
-import {Path} from 'path.js';
+import {Path} from './Path';
 
 export class Pointer{
 	constructor(container, index){
@@ -12,7 +12,7 @@ export class Pointer{
 		if (this.container.content.length == 0) return this.container;
 		if (this.index >= this.container.content.length) return null;
 
-		return this.container.content[index];
+		return this.container.content[this.index];
 	}
 
 	get isNull(){
@@ -23,7 +23,7 @@ export class Pointer{
 		if (this.isNull) return null;
 
 		if (this.index >= 0)
-			return this.container.path.PathByAppendingComponent(new Path.Component(index));
+			return this.container.path.PathByAppendingComponent(new Path.Component(this.index));
 		else
 			return this.container.path;
 	}
@@ -44,6 +44,8 @@ export class Pointer{
 	static StartOf(container){
 		return new Pointer(container, 0);
 	}
-}
 
-Pointer.Null = new Pointer(null, -1)
+	static get Null() {
+		return new Pointer(null, -1);
+	}
+}

--- a/engine/SearchResult.js
+++ b/engine/SearchResult.js
@@ -1,14 +1,24 @@
+import {Container} from "./Container";
+
 export class SearchResult{
 	constructor(){
 		this.obj;
 		this.approximate;
 	}
 
-	get correctObject(){
+	get correctObj(){
 		return this.approximate ? null : this.obj;
 	}
 
 	get container(){
 		return (this.obj instanceof Container) ? this.obj : null;
+	}
+
+	copy(){
+		var searchResult = new SearchResult()
+		searchResult.obj = this.obj;
+		searchResult.approximate = this.approximate;
+
+		return searchResult;
 	}
 }

--- a/engine/StringBuilder.js
+++ b/engine/StringBuilder.js
@@ -16,7 +16,7 @@ export class StringBuilder{
 	AppendFormat(format){
 		//taken from http://stackoverflow.com/questions/610406/javascript-equivalent-to-printf-string-format
 		var args = Array.prototype.slice.call(arguments, 1);
-		return format.replace(/{(\d+)}/g, function(match, number){
+		this._string += format.replace(/{(\d+)}/g, function(match, number){
 			return typeof args[number] != 'undefined' ? args[number] : match;
 		});
 	}

--- a/engine/Value.js
+++ b/engine/Value.js
@@ -31,7 +31,7 @@ class AbstractValue extends InkObject{
 	get valueObject(){
 		return this._valueObject;
 	}
-	
+
 	Cast(newType){
 		throw "Trying to casting an AbstractValue";
 	}
@@ -53,15 +53,15 @@ class AbstractValue extends InkObject{
 		} else if (val instanceof InkList) {
 			return new ListValue(val);
 		}
-	
+
 		return null;
 	}
 	Copy(val){
 		return AbstractValue.Create(val);
 	}
-  BadCastException (targetType) {
-    return new StoryException("Can't cast "+this.valueObject+" from " + this.valueType+" to "+targetType);
-  }
+	BadCastException (targetType) {
+		return new StoryException("Can't cast "+this.valueObject+" from " + this.valueType+" to "+targetType);
+	}
 }
 
 export class Value extends AbstractValue{
@@ -94,7 +94,7 @@ export class IntValue extends Value{
 	get valueType(){
 		return ValueType.Int;
 	}
-	
+
 	Cast(newType){
 		if (newType == this.valueType) {
 			return this;
@@ -123,7 +123,7 @@ export class FloatValue extends Value{
 	get valueType(){
 		return ValueType.Float;
 	}
-	
+
 	Cast(newType){
 		if (newType == this.valueType) {
 			return this;
@@ -145,16 +145,16 @@ export class StringValue extends Value{
 	constructor(val){
 		super(val || '');
 		this._valueType = ValueType.String;
-		
+
 		this._isNewline = (this.value == "\n");
 		this._isInlineWhitespace = true;
-		
+
 		this.value.split().every(c => {
 			if (c != ' ' && c != '\t'){
 				this._isInlineWhitespace = false;
 				return false;
 			}
-			
+
 			return true;
 		});
 	}
@@ -173,7 +173,7 @@ export class StringValue extends Value{
 	get isNonWhitespace(){
 		return !this.isNewline && !this.isInlineWhitespace;
 	}
-	
+
 	Cast(newType){
 		if (newType == this.valueType) {
 			return this;
@@ -205,7 +205,7 @@ export class StringValue extends Value{
 export class DivertTargetValue extends Value{
 	constructor(targetPath){
 		super(targetPath);
-		
+
 		this._valueType = ValueType.DivertTarget;
 	}
 	get targetPath(){
@@ -217,7 +217,7 @@ export class DivertTargetValue extends Value{
 	get isTruthy(){
 		throw "Shouldn't be checking the truthiness of a divert target";
 	}
-	
+
 	Cast(newType){
 		if (newType == this.valueType)
 			return this;
@@ -232,7 +232,7 @@ export class DivertTargetValue extends Value{
 export class VariablePointerValue extends Value{
 	constructor(variableName, contextIndex){
 		super(variableName);
-		
+
 		this._valueType = ValueType.VariablePointer;
 		this.contextIndex = (typeof contextIndex !== 'undefined') ? contextIndex : -1;
 	}
@@ -245,7 +245,7 @@ export class VariablePointerValue extends Value{
 	get isTruthy(){
 		throw "Shouldn't be checking the truthiness of a variable pointer";
 	}
-	
+
 	Cast(newType){
 		if (newType == this.valueType)
 			return this;
@@ -269,7 +269,7 @@ export class ListValue extends Value{
 		this.value.forEach(function(kv){
 			var listItemIntValue = kv.Value;
 			if (listItemIntValue != 0)
-				isTruthy = true; 
+				isTruthy = true;
 		});
 		return isTruthy;
 	}
@@ -306,9 +306,9 @@ export class ListValue extends Value{
 	}
 	constructor(listOrSingleItem, singleValue){
 		super(null);
-		
+
 		this._valueType = ValueType.List;
-		
+
 		if (listOrSingleItem instanceof InkList){
 			this.value = new InkList(listOrSingleItem);
 		}


### PR DESCRIPTION
This PR fixes a number of small typos that I've encountered while running the tests.

Merging it after #171 might introduce some mess in the history, so I'll rework the PR if that's the case.

Side note: I've added a `copy` method to `SearchResult` in order to highlight the fact that it's a value-type. It's not used anywhere.