### PR TITLE
Fix handling of empty string values

### DIFF
--- a/engine/Value.js
+++ b/engine/Value.js
@@ -149,14 +149,17 @@ export class StringValue extends Value{
 		this._isNewline = (this.value == "\n");
 		this._isInlineWhitespace = true;
 
-		this.value.split().every(c => {
-			if (c != ' ' && c != '\t'){
-				this._isInlineWhitespace = false;
-				return false;
-			}
-
-			return true;
-		});
+		// Splitting "" yields [""] which isn't what we want. Thanks JS!
+		if( this.value.length > 0 ) {
+			this.value.split().every(c => {
+				if (c != ' ' && c != '\t'){
+					this._isInlineWhitespace = false;
+					return false;
+				}
+	
+				return true;
+			});
+		}
 	}
 	get valueType(){
 		return ValueType.String;


### PR DESCRIPTION
Fixes part 2 of https://github.com/y-lohse/inkjs/issues/200. There's actually a bug in the compiler that is producing empty string values, but inkjs wasn't handling them the same as the C# ink, not that they should ever exist!