### PR TITLE
Revert "chore(deps): update dependency rollup-plugin-babel to v4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jasmine": "3.2.0",
     "npm-watch": "0.3.0",
     "rollup": "0.64.1",
-    "rollup-plugin-babel": "4.0.2",
+    "rollup-plugin-babel": "3.0.7",
     "rollup-plugin-node-resolve": "3.3.0"
   },
   "dependencies": {}


### PR DESCRIPTION
Reverts y-lohse/inkjs#208

While the PR was green, the merge broke the build. I'll have to investigate.