### PR TITLE
variableChangedEventCallbacks now preserved when VariableState is copied

### DIFF
--- a/src/VariablesState.ts
+++ b/src/VariablesState.ts
@@ -121,6 +121,7 @@ export class VariablesState{
 		this._defaultGlobalVariables = new Map(toCopy._defaultGlobalVariables);
 
 		this.variableChangedEvent = toCopy.variableChangedEvent;
+		this.variableChangedEventCallbacks = toCopy.variableChangedEventCallbacks;
 
 		if (toCopy.batchObservingVariableChanges != this.batchObservingVariableChanges) {
 


### PR DESCRIPTION
This missing line was breaking the variable observers.