### PR TITLE
Fix #469 (VariablesState.SetGlobal typedef is overly narrow)

### DIFF
--- a/src/VariablesState.ts
+++ b/src/VariablesState.ts
@@ -56,7 +56,7 @@ export class VariablesState{
 	// the original code uses a magic getter and setter for global variables,
 	// allowing things like variableState['varname]. This is not quite possible
 	// in js without a Proxy, so it is replaced with this $ function.
-	public $(variableName: string, value: InkObject){
+	public $(variableName: string, value: any){
 		if (typeof value === 'undefined'){
 			let varContents = this._globalVariables.get(variableName);
 


### PR DESCRIPTION
Just fixing the typo (`InkObject` -> `any`) raised by #469.