### PR TITLE
Activate disabled print_num test

### DIFF
--- a/tests/specs/ink/Logic.spec.js
+++ b/tests/specs/ink/Logic.spec.js
@@ -30,7 +30,7 @@ describe('Logic', () => {
 		expect(story.ContinueMaximally()).toBe("5\n625\n");
 	});
 
-	xit('tests print num', () => {
+	it('tests print num', () => {
 		loadStory("print_num");
 
 		expect(story.ContinueMaximally()).toBe(". four .\n. fifteen .\n. thirty-seven .\n. one hundred and one .\n. two hundred and twenty-two .\n. one thousand two hundred and thirty-four .\n");


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

After #515, this disabled test is now passing \o/
