### PR TITLE
fix: Remove calls to Array.push.apply

### DIFF
--- a/src/engine/Path.ts
+++ b/src/engine/Path.ts
@@ -159,7 +159,7 @@ export class Path {
   }
   public PathByAppendingComponent(c: Path.Component): Path {
     let p = new Path();
-    p._components.push.apply(p._components, this._components);
+    p._components.push(...this._components);
     p._components.push(c);
     return p;
   }

--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -1549,7 +1549,7 @@ export class Story extends InkObject {
     }
 
     let outputStreamBefore: InkObject[] = [];
-    outputStreamBefore.push.apply(outputStreamBefore, this.state.outputStream);
+    outputStreamBefore.push(...this.state.outputStream);
     this._state.ResetOutput();
 
     this.state.StartFunctionEvaluationFromGame(funcContainer, args);

--- a/src/engine/StoryState.ts
+++ b/src/engine/StoryState.ts
@@ -370,25 +370,19 @@ export class StoryState {
 
     copy._patch = new StatePatch(this._patch);
 
-    copy.outputStream.push.apply(copy.outputStream, this._outputStream);
+    copy.outputStream.push(...this._outputStream);
     copy.OutputStreamDirty();
 
-    copy._currentChoices.push.apply(copy._currentChoices, this._currentChoices);
+    copy._currentChoices.push(...this._currentChoices);
 
     if (this.hasError) {
       copy._currentErrors = [];
-      copy._currentErrors.push.apply(
-        copy._currentErrors,
-        this.currentErrors || []
-      );
+      copy._currentErrors.push(...(this.currentErrors || []));
     }
 
     if (this.hasWarning) {
       copy._currentWarnings = [];
-      copy._currentWarnings.push.apply(
-        copy._currentWarnings,
-        this.currentWarnings || []
-      );
+      copy._currentWarnings.push(...(this.currentWarnings || []));
     }
 
     copy.callStack = new CallStack(this.callStack);
@@ -397,7 +391,7 @@ export class StoryState {
     copy.variablesState.callStack = copy.callStack;
     copy.variablesState.patch = copy._patch;
 
-    copy.evaluationStack.push.apply(copy.evaluationStack, this.evaluationStack);
+    copy.evaluationStack.push(...this.evaluationStack);
 
     if (!this.divertedPointer.isNull)
       copy.divertedPointer = this.divertedPointer.copy();
@@ -601,7 +595,7 @@ export class StoryState {
   }
   public ResetOutput(objs: InkObject[] | null = null) {
     this._outputStream.length = 0;
-    if (objs !== null) this._outputStream.push.apply(this._outputStream, objs);
+    if (objs !== null) this._outputStream.push(...objs);
     this.OutputStreamDirty();
   }
 


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

Fixes #176 
The orignal code uses `Collection.AddRange` in several places, and using `Array.push.apply` was only one of the workarounds. There may be other places that could benefit from destructuring parameters passed to `Array.push`.
