### PR TITLE
chore: Use babel-env only for configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/transform-object-assign"]
+  "presets": ["@babel/preset-env"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inkjs",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2239,23 +2239,6 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.1.tgz",
       "integrity": "sha512-MBlzPc1nJvbmO9rPr1fQwXOM2iGut+JC92ku6PbiJMMK7SnQc1rytgpopveE3Evn47gzvGYeCdgfCDbZo0ecUw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/plugin-transform-object-assign": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.1.tgz",
-      "integrity": "sha512-poBEVwzcTjv6p92ZcnWBUftzyXFCy/Zg/eCQsayu5/ot2+qwnasNvCCKPwdgprgDRzbHVUhh/fzI9rCoFOHLbg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.1"

--- a/package.json
+++ b/package.json
@@ -19,21 +19,24 @@
   },
   "author": "Yannick Lohse",
   "license": "MIT",
+  "browserslist": "> 0.25%, not dead",
   "devDependencies": {
     "@babel/core": "7.10.2",
-    "@babel/plugin-transform-object-assign": "7.10.1",
     "@babel/preset-env": "7.10.2",
     "@types/jest": "26.0.0",
-    "fs-extra": "9.0.1",
     "@typescript-eslint/eslint-plugin": "3.2.0",
     "@typescript-eslint/eslint-plugin-tslint": "3.2.0",
     "@typescript-eslint/parser": "3.2.0",
     "eslint": "7.2.0",
+    "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.21.2",
     "eslint-plugin-jsdoc": "27.0.6",
     "eslint-plugin-prefer-arrow": "1.2.1",
+    "eslint-plugin-prettier": "3.1.3",
+    "fs-extra": "9.0.1",
     "glob": "7.1.6",
     "jest": "26.0.1",
+    "prettier": "2.0.5",
     "remap-istanbul": "0.13.0",
     "rollup": "2.15.0",
     "rollup-plugin-babel": "4.4.0",
@@ -44,9 +47,6 @@
     "rollup-plugin-uglify": "6.0.4",
     "ts-jest": "26.1.0",
     "tslint": "5.20.1",
-    "typescript": "3.9.5",
-    "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-prettier": "3.1.3",
-    "prettier": "2.0.5"
+    "typescript": "3.9.5"
   }
 }


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

We don't really need to specify plugins manually, `babel-env` can detect what is required… provided we give it a browserlist, which this PR does.

(Also we don't use Object.assign anywhere anymore…)
