### PR TITLE
feat: migrate Story.ts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ the [main repository] first, or alternatively, in the official [Discord server].
    when it make sense. For example, it's important to document when `inkjs`
    display a slightly different behavior than the reference implementation.
 
+2. Try to match the C# type, that means that `String` translates to `string | null`
+   in TypeScript. In order to reduce confusion however, exposed methods
+   that interact with JavaScript should use optional parameter / return types
+   (i. e. `variable?: <type>`) when they are optional / nullable in
+   the original codebase.
+
 _To be added._
 
 ### Style guide

--- a/src/engine/Error.ts
+++ b/src/engine/Error.ts
@@ -1,3 +1,5 @@
+export type ErrorHandler = (message: string, type: ErrorType) => void;
+
 export enum ErrorType {
   Author,
   Warning,

--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -437,7 +437,7 @@ export class Story extends InkObject {
         this._state.variablesState.batchObservingVariableChanges = false;
 
       this._asyncContinueActive = false;
-      if (this.onDidContinue !== null) this.onDidContinue;
+      if (this.onDidContinue !== null) this.onDidContinue();
     }
 
     this._recursiveContinueCount--;

--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -437,7 +437,7 @@ export class Story extends InkObject {
         this._state.variablesState.batchObservingVariableChanges = false;
 
       this._asyncContinueActive = false;
-      if (this.onDidContinue != null) this.onDidContinue;
+      if (this.onDidContinue !== null) this.onDidContinue;
     }
 
     this._recursiveContinueCount--;
@@ -445,7 +445,7 @@ export class Story extends InkObject {
     if (this._profiler != null) this._profiler.PostContinue();
 
     if (this.state.hasError || this.state.hasWarning) {
-      if (this.onError != null) {
+      if (this.onError !== null) {
         if (this.state.hasError) {
           for (let err of this.state.currentErrors) {
             this.onError(err, ErrorType.Error);

--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -1964,37 +1964,49 @@ export class Story extends InkObject {
   }
 
   public RemoveVariableObserver(
-    observer: Story.VariableObserver | null = null,
-    specificVariableName: string
+    observer?: Story.VariableObserver,
+    specificVariableName?: string
   ) {
+    // A couple of things to know about this method:
+    //
+    // 1. Since `RemoveVariableObserver` is exposed to the JavaScript world,
+    //    optionality is marked as `undefined` rather than `null`.
+    //    To keep things simple, null-checks are performed using regular
+    //    equality operators, where undefined == null.
+    //
+    // 2. Since C# delegates are translated to arrays of functions,
+    //    -= becomes a call to splice and null-checks are replaced by
+    //    emptiness-checks.
+    //
     this.IfAsyncWeCant("remove a variable observer");
 
     if (this._variableObservers === null) return;
 
-    if (typeof specificVariableName !== "undefined") {
+    if (specificVariableName != null) {
       if (this._variableObservers.has(specificVariableName)) {
-        if (observer !== null) {
-          let observers = this._variableObservers.get(specificVariableName)!;
-
-          if (observers !== null) {
-            observers.splice(observers.indexOf(observer), 1);
-          } else {
-            this._variableObservers.delete(specificVariableName);
+        if (observer != null) {
+          let variableObservers = this._variableObservers.get(
+            specificVariableName
+          );
+          if (variableObservers != null) {
+            variableObservers.splice(variableObservers.indexOf(observer), 1);
+            if (variableObservers.length === 0) {
+              this._variableObservers.delete(specificVariableName);
+            }
           }
         } else {
           this._variableObservers.delete(specificVariableName);
         }
       }
-    } else if (observer !== null) {
+    } else if (observer != null) {
       let keys = this._variableObservers.keys();
-
       for (let varName of keys) {
-        let observers = this._variableObservers.get(varName)!;
-
-        if (observers !== null) {
-          observers.splice(observers.indexOf(observer), 1);
-        } else {
-          this._variableObservers.delete(specificVariableName);
+        let variableObservers = this._variableObservers.get(varName);
+        if (variableObservers != null) {
+          variableObservers.splice(variableObservers.indexOf(observer), 1);
+          if (variableObservers.length === 0) {
+            this._variableObservers.delete(varName);
+          }
         }
       }
     }

--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -470,7 +470,6 @@ export class Story extends InkObject {
           sb.Append(
             this.state.currentWarnings.length == 1 ? " warning" : "warnings"
           );
-          if (this.state.hasWarning) sb.Append(" and ");
         }
         sb.Append(
           ". It is strongly suggested that you assign an error handler to story.onError. The first issue was: "


### PR DESCRIPTION
There's a lot more changes than in the last few PR.

### Highlights

- The new Error Handler / Callbacks are types as `Function | null`, instead of just being optional, so that it matches the C# code better.
- There'a couple of errors, I'll fix them once `StoryState` is ported.
- The original integer overflow logic is different.
- I've tweaked the logic in `RemoveVariableObserver`, if I remember correctly a kind contributors created a PR in both repos, but the TypeScript code didn't seemt to match upstream. You may want to have a hard look at this.