### PR TITLE
chore: Update publication workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,16 +21,15 @@ jobs:
       - run: npm run test
 
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm install
       - name: Build


### PR DESCRIPTION
It looks like we've never published ink.js since we switched to github actions, and apparently there was a bug in the action configuration. I've updated the file according to the latest version of the official docs, let's see how this goes.