### PR TITLE
chore: Run tests before publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm run test
 
   publish-npm:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
#878 worked but after seeing the workflow in action. I realize that both jobs run in parallel, but the publish step should run only if the test job is successful. So really the initial config was almost correct, except that `needs` should have been `test` and not `build`.