### PR TITLE
Typing changes for VariablesState and Story

### DIFF
--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -1828,7 +1828,7 @@ export class Story extends InkObject {
   public BindExternalFunction(
     funcName: string,
     func: Story.ExternalFunction,
-    lookaheadSafe: boolean
+    lookaheadSafe: boolean = false
   ) {
     this.Assert(func != null, "Can't bind a null function");
 

--- a/src/engine/VariablesState.ts
+++ b/src/engine/VariablesState.ts
@@ -20,6 +20,9 @@ import { StatePatch } from "./StatePatch";
 import { SimpleJson } from "./SimpleJson";
 
 export class VariablesState {
+  // Required for TypeScript access of the proxy
+  [key: string]: any;
+
   // The way variableChangedEvent is a bit different than the reference implementation.
   // Originally it uses the C# += operator to add delegates, but in js we need to maintain
   // an actual collection of delegates (ie. callbacks) to register a new one, there is a
@@ -70,14 +73,14 @@ export class VariablesState {
   // the original code uses a magic getter and setter for global variables,
   // allowing things like variableState['varname]. This is not quite possible
   // in js without a Proxy, so it is replaced with this $ function.
-  public $(variableName: string, value: any) {
+  public $<T = any>(variableName: string, value?: T): T | null | undefined {
     if (typeof value === "undefined") {
       let varContents = null;
 
       if (this.patch !== null) {
         varContents = this.patch.TryGetGlobal(variableName, null);
         if (varContents.exists)
-          return (varContents.result as AbstractValue).valueObject;
+          return (varContents.result as AbstractValue).valueObject as T;
       }
 
       varContents = this._globalVariables.get(variableName);
@@ -87,7 +90,7 @@ export class VariablesState {
       }
 
       if (typeof varContents !== "undefined")
-        return (varContents as AbstractValue).valueObject;
+        return (varContents as AbstractValue).valueObject as T;
       else return null;
     } else {
       if (typeof this._defaultGlobalVariables.get(variableName) === "undefined")
@@ -102,9 +105,7 @@ export class VariablesState {
         if (value == null) {
           throw new Error("Cannot pass null to VariableState");
         } else {
-          throw new Error(
-            "Invalid value passed to VariableState: " + value.toString()
-          );
+          throw new Error(`Invalid value passed to VariableState: ${value}`);
         }
       }
 

--- a/src/tests/specs/ink/Bindings.spec.ts
+++ b/src/tests/specs/ink/Bindings.spec.ts
@@ -1,7 +1,8 @@
 import * as testsUtils from "../common";
+import { Story } from "../../../engine/Story";
 
 describe("Bindings", () => {
-  let story: any;
+  let story: Story | undefined;
 
   function loadStory(name: string) {
     story = testsUtils.loadInkFile(name, "bindings");
@@ -16,15 +17,15 @@ describe("Bindings", () => {
 
     let testExternalBindingMessage = "";
 
-    story.BindExternalFunction("message", (arg: any) => {
+    story?.BindExternalFunction("message", (arg: any) => {
       testExternalBindingMessage = "MESSAGE: " + arg;
     });
 
-    story.BindExternalFunction("multiply", (arg1: any, arg2: any) => {
+    story?.BindExternalFunction("multiply", (arg1: any, arg2: any) => {
       return arg1 * arg2;
     });
 
-    story.BindExternalFunction(
+    story?.BindExternalFunction(
       "times",
       (numberOfTimes: any, stringValue: any) => {
         let result = "";
@@ -37,21 +38,21 @@ describe("Bindings", () => {
       }
     );
 
-    expect(story.Continue()).toBe("15\n");
-    expect(story.Continue()).toBe("knock knock knock\n");
+    expect(story?.Continue()).toBe("15\n");
+    expect(story?.Continue()).toBe("knock knock knock\n");
     expect(testExternalBindingMessage).toBe("MESSAGE: hello world");
   });
 
   it("tests game ink back and forth", () => {
     loadStory("game_ink_back_and_forth");
 
-    story.BindExternalFunction("gameInc", (x: any) => {
+    story?.BindExternalFunction("gameInc", (x: any) => {
       x += 1;
-      x = story.EvaluateFunction("inkInc", [x]);
+      x = story?.EvaluateFunction("inkInc", [x]);
       return x;
     });
 
-    let finalResult = story.EvaluateFunction("topExternal", [5], true);
+    let finalResult = story?.EvaluateFunction("topExternal", [5], true);
 
     expect(finalResult["returned"]).toBe(7);
     expect(finalResult["output"]).toBe("In top external\n");
@@ -63,18 +64,18 @@ describe("Bindings", () => {
     let currentVarValue = 0;
     let observerCallCount = 0;
 
-    story.ObserveVariable("testVar", (varName: any, newValue: any) => {
+    story?.ObserveVariable("testVar", (varName: any, newValue: any) => {
       currentVarValue = newValue;
       observerCallCount += 1;
     });
 
-    story.ContinueMaximally();
+    story?.ContinueMaximally();
 
     expect(currentVarValue).toBe(15);
     expect(observerCallCount).toBe(1);
 
-    story.ChooseChoiceIndex(0);
-    story.Continue();
+    story?.ChooseChoiceIndex(0);
+    story?.Continue();
 
     expect(currentVarValue).toBe(25);
     expect(observerCallCount).toBe(2);
@@ -85,7 +86,7 @@ describe("Bindings", () => {
     loadStory("lookup_safe_or_not");
 
     let callCount = 0;
-    story.BindExternalFunction(
+    story?.BindExternalFunction(
       "myAction",
       () => {
         callCount++;
@@ -93,14 +94,14 @@ describe("Bindings", () => {
       true
     );
 
-    story.ContinueMaximally();
+    story?.ContinueMaximally();
     expect(callCount).toBe(2);
 
     // UNSAFE Lookahead
     callCount = 0;
-    story.ResetState();
-    story.UnbindExternalFunction("myAction");
-    story.BindExternalFunction(
+    story?.ResetState();
+    story?.UnbindExternalFunction("myAction");
+    story?.BindExternalFunction(
       "myAction",
       () => {
         callCount++;
@@ -108,7 +109,7 @@ describe("Bindings", () => {
       false
     );
 
-    story.ContinueMaximally();
+    story?.ContinueMaximally();
     expect(callCount).toBe(1);
 
     // SAFE Lookahead with glue broken intentionally
@@ -116,8 +117,8 @@ describe("Bindings", () => {
 
     // Disabling this rule to match the tests from upstream.
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    story.BindExternalFunction("myAction", () => {});
-    let result = story.ContinueMaximally();
+    story?.BindExternalFunction("myAction", () => {});
+    let result = story?.ContinueMaximally();
     expect(result).toBe("One\nTwo\n");
   });
 });

--- a/src/tests/specs/inkjs/Integration.spec.ts
+++ b/src/tests/specs/inkjs/Integration.spec.ts
@@ -1,7 +1,8 @@
 import * as testsUtils from "../common";
+import { Story } from "../../../engine/Story";
 
 describe("Integration", () => {
-  let story: any;
+  let story: Story;
   let inkPath = testsUtils.getInkPath();
 
   beforeEach(() => {


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

This makes the experience of using inkjs from TypeScript slightly better by:

1. Adding typed access to a story's VariablesState. Now, a TypeScript user can do `story.variablesState['name']` or `story.variablesState.$<string>('name')` and either get the convenience that the indexed access affords _or_ the typed access via the generic param of `$`. Also, the `$` function didn't allow for fetching a value without a TypeScript error. That's fixed!
2.  In `Story.BindExternalFunction`, the `lookaheadSafe` parameter is now `false` by default. According to [Ink's source](https://github.com/inkle/ink/blob/0fe3c9f29d80a4eb4a9d7069796e357129f932ca/ink-engine-runtime/Story.cs#L1878-L1886):

    > Usually, you want to pass 'false', especially if you want some action to be performed in game code when this function is called

    As far as I can tell from the C#, `false` should generally be the default. This makes the specs' usage of `BindExternalFunction` correct and saves TypeScript users from having to pass `true` or `false` everytime!