### PR TITLE
Switch `prepublishOnly` to `prepare` to allow for git installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/ink-es2015.js",
   "types": "ink.d.ts",
   "scripts": {
-    "test": "npm run-script test:typescript && npm run-script test:javascript",
+    "test": "npm run test:typescript && npm run test:javascript",
     "test:typescript": "jest",
-    "test:javascript": "npm run-script test:javascript:dist && npm run-script test:javascript:legacy",
+    "test:javascript": "npm run test:javascript:dist && npm run test:javascript:legacy",
     "test:javascript:dist": "INK_TEST=dist jest --config='jest.config.javascript.js'",
     "test:javascript:legacy": "INK_TEST=legacy jest --config='jest.config.javascript.js'",
     "test:compileFiles": "node src/tests/compile.js",
@@ -15,7 +15,7 @@
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "npm run lint -- --fix",
     "watch": "tsc -p ./ && rollup -c -w",
-    "prepare": "npm run-script build"
+    "prepare": "npm run build"
   },
   "author": "Yannick Lohse",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "npm run lint -- --fix",
     "watch": "tsc -p ./ && rollup -c -w",
-    "prepublishOnly": "tsc -p ./ && rollup -c"
+    "prepare": "npm run-script build"
   },
   "author": "Yannick Lohse",
   "license": "MIT",


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

When trying to install the package from GitHub, I found that the built JavaScript files were missing! This adds that build step in by switching the `prepublishOnly` script to `prepare`.

Admittedly, this also means that running `npm install` in the repo's directory during development will always build the full JS. I'd like to make that build even faster 👹, but until then: `npm install --ignore-scripts` is the way to go.
