### PR TITLE
[request] add es6 module support

### DIFF
--- a/ink.d.ts
+++ b/ink.d.ts
@@ -7,3 +7,4 @@ declare interface Inkjs {
 
 declare let inkjs: Inkjs
 export = inkjs
+export default inkjs

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,26 @@ export default [
     input: inputFile,
     output: {
       name: moduleName,
+      file: 'dist/ink-es6.js',
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [
+      nodeResolve(),
+      typescript(tsconfig),
+      babel({
+        exclude: 'node_modules/**',
+        extensions: ['.js', '.ts'],
+        babelHelpers: 'bundled'
+      }),
+      terser(),
+      sourcemaps()
+    ]
+  },
+  {
+    input: inputFile,
+    output: {
+      name: moduleName,
       file: 'dist/ink.js',
       format: format,
       sourcemap: true


### PR DESCRIPTION
## Goals
ES modules need a default export to function properly with other es modules.  Since this project is modern and uses modules under the hood, it was simple enough to add support by adding an additional export in the entry point along with the corresponding rollup build step. 

All tests pass, however there were some existing lint issues that remain from the moment of the fork to the modifications. 

Thanks!
