### PR TITLE
Port missing characterInLineIndex in debugMetadata

### DIFF
--- a/src/compiler/Parser/InkParser.ts
+++ b/src/compiler/Parser/InkParser.ts
@@ -166,9 +166,9 @@ export class InkParser extends StringParser {
     stateAtEnd: StringParserElement
   ): DebugMetadata => {
     const md = new DebugMetadata();
-    md.startLineNumber = stateAtStart?.lineIndex || 0 + 1;
+    md.startLineNumber = (stateAtStart?.lineIndex || 0) + 1;
     md.endLineNumber = stateAtEnd.lineIndex + 1;
-    md.startCharacterNumber = stateAtStart?.characterInLineIndex || 0 + 1;
+    md.startCharacterNumber = (stateAtStart?.characterInLineIndex || 0) + 1;
     md.endCharacterNumber = stateAtEnd.characterInLineIndex + 1;
     md.fileName = this._filename;
 

--- a/src/compiler/Parser/StringParser/StringParser.ts
+++ b/src/compiler/Parser/StringParser/StringParser.ts
@@ -424,6 +424,7 @@ export abstract class StringParser {
     // since they're properties that would have to access
     // the rule stack every time otherwise.
     let i: number = this.index;
+    let cli: number = this.characterInLineIndex;
     let li: number = this.lineIndex;
 
     let success: boolean = true;
@@ -436,12 +437,15 @@ export abstract class StringParser {
       }
       if (c === "\n") {
         li++;
+        cli = -1;
       }
 
       i++;
+      cli++;
     }
 
     this.index = i;
+    this.characterInLineIndex = cli;
     this.lineIndex = li;
 
     if (success) {
@@ -456,9 +460,11 @@ export abstract class StringParser {
       const c = this._chars[this.index];
       if (c === "\n") {
         this.lineIndex += 1;
+        this.characterInLineIndex = -1;
       }
 
       this.index += 1;
+      this.characterInLineIndex += 1;
 
       return c;
     }
@@ -513,6 +519,7 @@ export abstract class StringParser {
     // since they're properties that would have to access
     // the rule stack every time otherwise.
     let ii: number = this.index;
+    let cli: number = this.characterInLineIndex;
     let li: number = this.lineIndex;
     let count: number = 0;
     while (
@@ -522,13 +529,16 @@ export abstract class StringParser {
     ) {
       if (this._chars[ii] === "\n") {
         li += 1;
+        cli = -1;
       }
 
       ii += 1;
+      cli += 1;
       count += 1;
     }
 
     this.index = ii;
+    this.characterInLineIndex = cli;
     this.lineIndex = li;
 
     const lastCharIndex: number = this.index;
@@ -604,9 +614,11 @@ export abstract class StringParser {
           parsedString += pauseCharacter;
           if (pauseCharacter === "\n") {
             this.lineIndex += 1;
+            this.characterInLineIndex = -1;
           }
 
           this.index += 1;
+          this.characterInLineIndex += 1;
 
           continue;
         } else {
@@ -625,6 +637,7 @@ export abstract class StringParser {
   // No need to Begin/End rule since we never parse a newline, so keeping oldIndex is good enough
   public readonly ParseInt = (): number | null => {
     const oldIndex: number = this.index;
+    const oldCharacterInLineIndex: number = this.characterInLineIndex;
     const negative: boolean = this.ParseString("-") !== null;
 
     // Optional whitespace
@@ -636,6 +649,7 @@ export abstract class StringParser {
     if (parsedString === null) {
       // Roll back and fail
       this.index = oldIndex;
+      this.characterInLineIndex = oldCharacterInLineIndex;
 
       return null;
     }
@@ -662,6 +676,7 @@ export abstract class StringParser {
   // No need to Begin/End rule since we never parse a newline, so keeping oldIndex is good enough
   public readonly ParseFloat = (): number | null => {
     const oldIndex: number = this.index;
+    const oldCharacterInLineIndex: number = this.characterInLineIndex;
 
     const leadingInt: number | null = this.ParseInt();
     if (leadingInt !== null) {
@@ -676,6 +691,7 @@ export abstract class StringParser {
 
     // Roll back and fail
     this.index = oldIndex;
+    this.characterInLineIndex = oldCharacterInLineIndex;
 
     return null;
   };

--- a/src/compiler/Parser/StringParser/StringParserElement.ts
+++ b/src/compiler/Parser/StringParser/StringParserElement.ts
@@ -12,6 +12,7 @@ export class StringParserElement {
     StringParserElement._uniqueIdCounter++;
     this.uniqueId = StringParserElement._uniqueIdCounter;
     this.characterIndex = fromElement.characterIndex;
+    this.characterInLineIndex = fromElement.characterInLineIndex;
     this.lineIndex = fromElement.lineIndex;
     this.customFlags = fromElement.customFlags;
     this.reportedErrorInScope = false;
@@ -25,6 +26,7 @@ export class StringParserElement {
   // state of the individual rule too.
   public readonly SquashFrom = (fromElement: StringParserElement): void => {
     this.characterIndex = fromElement.characterIndex;
+    this.characterInLineIndex = fromElement.characterInLineIndex;
     this.lineIndex = fromElement.lineIndex;
     this.reportedErrorInScope = fromElement.reportedErrorInScope;
   };


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

The `characterInLineIndex` property of debugMetadata was not computed (oversight in the port) _and_ the other properties were exposed incorrectly, leading to the wrong line being reported when a parsing error occured.

To be merged in https://github.com/y-lohse/inkjs/pull/937