### PR TITLE
change the magic number 16807 to 16811

### DIFF
--- a/src/engine/PRNG.ts
+++ b/src/engine/PRNG.ts
@@ -8,7 +8,7 @@ export class PRNG {
     if (this.seed <= 0) this.seed += 2147483646;
   }
   public next(): number {
-    return (this.seed = (this.seed * 16807) % 2147483647);
+    return (this.seed = (this.seed * 16811) % 2147483647);
   }
   public nextFloat(): number {
     return (this.next() - 1) / 2147483646;

--- a/src/tests/specs/inkjs/Logic.spec.ts
+++ b/src/tests/specs/inkjs/Logic.spec.ts
@@ -155,7 +155,7 @@ describe("Logic", () => {
   it("should generate random numbers", () => {
     story.ChoosePathString("logic.random");
 
-    expect(story.Continue()).toEqual("15\n");
-    expect(story.Continue()).toEqual("-24\n");
+    expect(story.Continue()).toEqual("14\n");
+    expect(story.Continue()).toEqual("-10\n");
   });
 });


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

I detected a problem in the combination of `ink v1.0.0` and `ink.js v2.0.0`.
If the length of a shuffle list is `7`, it will always return the first element.
Such as:
```
{~1|2|3|4|5|6|7}
LIST lst = (a),(b),(c),(d),(e),(f),(g)
{LIST_RANDOM(lst)}
```
which always get `1` and `a`. However, the problem disappears for other lengths such as `6` or `8`. It made me confused.

So I inferred that there is a magic number.
By checking the source, I identified it is `16807`.

This number is a multiple of `7`.
If `this.seed * 16807 < 2147483647`, `PRNG.next() % 7` should always be zero.
In the implmentation of `LIST_RANDOM`, it uses `PRNG.next() % list.Count`.
So I think this is why we always get the first element on `length == 7`.

My solution is to replace `16807` with `16811`. The latter is a prime.
I tested on our usecases to confirm that this modification solves the magical problem.