### PR TITLE
Disable web animations when the user prefers reduced motion

### DIFF
--- a/templates/browser_serverless/main.js
+++ b/templates/browser_serverless/main.js
@@ -4,12 +4,19 @@
 
     var storyContainer = document.querySelectorAll('#story')[0];
 
+    function isAnimationEnabled() {
+        return window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+    }
+
     function showAfter(delay, el) {
-        setTimeout(function() { el.classList.add("show") }, delay);
+        setTimeout(function() { el.classList.add("show") }, isAnimationEnabled() ? delay : 0);
     }
 
     function scrollToBottom() {
-        var progress = 0.0;
+        // If the user doesn't want animations, let them scroll manually
+        if (!isAnimationEnabled()) {
+            return;
+        }
         var start = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
         var dist = document.body.scrollHeight - window.innerHeight - start;
         if( dist < 0 ) return;

--- a/templates/browser_serverless/style.css
+++ b/templates/browser_serverless/style.css
@@ -23,7 +23,12 @@ p, a {
 
 p {
     opacity: 0.0;
-    transition: opacity 1.0s;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    p {
+        transition: opacity 1.0s;
+    }
 }
 
 p.show {

--- a/templates/browser_with_server/main.js
+++ b/templates/browser_with_server/main.js
@@ -13,12 +13,19 @@
 		continueStory();
 	});
 
+    function isAnimationEnabled() {
+        return window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+    }
+
     function showAfter(delay, el) {
-        setTimeout(function() { el.classList.add("show") }, delay);
+        setTimeout(function() { el.classList.add("show") }, isAnimationEnabled() ? delay : 0);
     }
 
     function scrollToBottom() {
-        var progress = 0.0;
+        // If the user doesn't want animations, let them scroll manually
+        if (!isAnimationEnabled()) {
+            return;
+        }
         var start = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
         var dist = document.body.scrollHeight - window.innerHeight - start;
         if( dist < 0 ) return;

--- a/templates/browser_with_server/style.css
+++ b/templates/browser_with_server/style.css
@@ -23,7 +23,12 @@ p, a {
 
 p {
     opacity: 0.0;
-    transition: opacity 1.0s;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    p {
+        transition: opacity 1.0s;
+    }
 }
 
 p.show {


### PR DESCRIPTION
The [`prefers-reduced-motion` media query](https://css-tricks.com/introduction-reduced-motion-media-query/) allows users to specify an accessibility setting for less animation. The purpose of this PR is to respect this setting.

## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

…but I'm cheating: these scripts don't look at template files.

## Description

When the user requests reduced animations, disable:

- Scrolling: Smooth scrolling triggers seasickness, so disable it. Instant scrolling is usually preferred but would be disorienting in the context of Ink games. Instead, let the user scroll at their own pace.
- Fade-in: A row of flashing paragraphs can also be a vestibular trigger. Show all the paragraphs at once.

## See also

[PR for Inky](https://github.com/inkle/inky/pull/427) with similar changes.