### PR TITLE
Fix: accidentally cloning origin names when constructing a list

### DIFF
--- a/src/engine/InkList.ts
+++ b/src/engine/InkList.ts
@@ -128,7 +128,7 @@ export class InkList extends Map<SerializedInkListItem, number> {
     if (arguments[0] instanceof InkList) {
       let otherList = arguments[0] as InkList;
 
-      var otherOriginNames = otherList.originNames;
+      let otherOriginNames = otherList.originNames as string[];
       if (otherOriginNames !== null)
         this._originNames = otherOriginNames.slice();
       if (otherList.origins !== null) {

--- a/src/engine/InkList.ts
+++ b/src/engine/InkList.ts
@@ -128,7 +128,9 @@ export class InkList extends Map<SerializedInkListItem, number> {
     if (arguments[0] instanceof InkList) {
       let otherList = arguments[0] as InkList;
 
-      this._originNames = otherList.originNames;
+      var otherOriginNames = otherList.originNames;
+      if (otherOriginNames !== null)
+        this._originNames = otherOriginNames.slice();
       if (otherList.origins !== null) {
         this.origins = otherList.origins.slice();
       }


### PR DESCRIPTION
This is a port of inkle/ink commit af9ec78.

The ink script 

```
LIST ListA = a, b, c 
LIST ListB = (p), q, r

{LIST_ALL(ListA)} 
~ addStates()
{LIST_ALL(ListA)} 

=== function addStates 
    ~ return ListA + ListB 
```

previously generated

```
a, b, c

p, q, r
```

It should generate 

```
a, b, c

a, b, c
```
