### PR TITLE
Fix INCLUDE paths in inkjs-compiler

### DIFF
--- a/script/inkjs-compiler.ts
+++ b/script/inkjs-compiler.ts
@@ -6,6 +6,7 @@ var readline = require('readline');
 var path = require('path');
 
 import * as fs from "fs";
+import { ErrorHandler } from '../src/engine/Error';
 
 const help = process.argv.includes("-h");
 if(help){
@@ -40,12 +41,19 @@ outputfile = outputfile || inputFile+".json";
 const fileHandler = new PosixFileHandler(path.dirname(inputFile));
 const mainInk = fileHandler.LoadInkFileContents(inputFile);
 
+const errorHandler: ErrorHandler = (message, errorType) => {
+    process.stderr.write(message + "\n");
+};
 const options = new CompilerOptions(
-    inputFile, [], countAllVisit, null, fileHandler
+    inputFile, [], countAllVisit, errorHandler, fileHandler
 )
 
-const c = new Compiler(mainInk, options)
+const c = new Compiler(mainInk, options);
 const rstory = c.Compile();
+if (!rstory) {
+    process.stderr.write("*** Compilation failed ***\n");
+    process.exit(1);
+}
 
 const jsonStory = rstory.ToJson()
 

--- a/src/compiler/FileHandler/PosixFileHandler.ts
+++ b/src/compiler/FileHandler/PosixFileHandler.ts
@@ -8,10 +8,10 @@ export class PosixFileHandler implements IFileHandler {
 
   readonly ResolveInkFilename = (filename: string): string => {
     if (this.rootPath !== undefined && this.rootPath !== "") {
-      return path.join(this.rootPath, filename.replace(this.rootPath, ""));
+      return path.join(this.rootPath, filename);
     } else {
       let workingDir = process.cwd();
-      return path.join(workingDir, filename.replace(workingDir, ""));
+      return path.join(workingDir, filename);
     }
   };
 


### PR DESCRIPTION
## Checklist

<!--
    Thank you for your contribution! Before submitting this PR, please
    make sure that:
-->

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
<!-- NOTE:
    Running `npm run-script lint:fix` will fix most of the
    linting problems automatically.
-->

## Description

This fixes a couple of problems I ran into when trying to run `inkjs-compiler` on Ink source split across multiple files:

- Adds a basic error handler that prints errors to process.stderr
- Don't mangle filenames in `PosixFileHandler`

The file handler was removing the current directory from anywhere in the filename, which is definitely incorrect (e.g. if the current directory is "." it will remove all dots from the filename).

I guess the intention may have been to the remove the current directory from the start of the filename, but I don't think that's correct either — it would break if the working directory were say `ink` and we tried to include `ink/ink/foo.ink`.

So, this PR just interprets the filename as being relative to the working dir, which does the right thing for my use case.