### PR TITLE
Fix incorrect substring in TrySplittingHeadTailWhitespace

### DIFF
--- a/src/engine/StoryState.ts
+++ b/src/engine/StoryState.ts
@@ -815,10 +815,7 @@ export class StoryState {
     }
 
     if (innerStrEnd > innerStrStart) {
-      let innerStrText = str.substring(
-        innerStrStart,
-        innerStrEnd - innerStrStart
-      );
+      let innerStrText = str.substring(innerStrStart, innerStrEnd);
       listTexts.push(new StringValue(innerStrText));
     }
 


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

This method was calling [substring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) with (start, length) instead of (start, end).

I ran into this with an ink file including command output that looks like this: `\nFoo bar`. It would print `Foo ba` instead of `Foo bar`.

I'm not an ink expert, so I could use some help adding a unit test for this!