### PR TITLE
inkjs-compiler: fix non-ascii identifiers

### DIFF
--- a/src/compiler/Parser/CharacterRange.ts
+++ b/src/compiler/Parser/CharacterRange.ts
@@ -46,10 +46,11 @@ export class CharacterRange {
   public readonly ToCharacterSet = (): CharacterSet => {
     if (this._correspondingCharSet.set.size === 0) {
       for (
-        let ii = this.start.charCodeAt(0), c = String.fromCharCode(ii);
+        let ii = this.start.charCodeAt(0), c;
         ii <= this.end.charCodeAt(0);
         ii += 1
       ) {
+        c = String.fromCharCode(ii);
         if (!this._excludes.has(c)) {
           this._correspondingCharSet.AddCharacters(c);
         }


### PR DESCRIPTION
## Checklist

- [X] The new code additions passed the tests (`npm test`).
- [X] The linter ran and found no issues (`npm run-script lint`).

## Description

The `CharacterRange.ToCharacterSet` method returns only the first character defined by CharacterRange. Therefore, `InkParser.ExtendIdentifierCharacterRanges` extends `identifierCharSet` only with the first character of each character set.

This pull request fixes the `ToCharacterSet` method behavior, returning all characters from CharacterRange.
