### PR TITLE
include Parser and StatementLevel in full bundle exports

### DIFF
--- a/src/compiler/Compiler.ts
+++ b/src/compiler/Compiler.ts
@@ -9,6 +9,8 @@ import { StringValue } from "../engine/Value";
 import { asOrNull } from "../engine/TypeAssertion";
 
 export { CompilerOptions } from "./CompilerOptions";
+export { InkParser } from "./Parser/InkParser";
+export { StatementLevel } from "./Parser/StatementLevel";
 export { JsonFileHandler } from "./FileHandler/JsonFileHandler";
 export { InkList, Story } from "../engine/Story";
 


### PR DESCRIPTION
Adds `Parser` and `StatementLevel` to the exports of the full bundle, so that they are accessable to other packages.

This does not increase the bundle size