### PR TITLE
add additional typeName fields to ParsedHierarchy objects

### DIFF
--- a/src/compiler/Parser/ParsedHierarchy/Argument.ts
+++ b/src/compiler/Parser/ParsedHierarchy/Argument.ts
@@ -6,4 +6,8 @@ export class Argument {
     public isByReference: boolean | null = null,
     public isDivertTarget: boolean | null = null
   ) {}
+
+  get typeName(): string {
+    return "Argument";
+  }
 }

--- a/src/compiler/Parser/ParsedHierarchy/IncludedFile.ts
+++ b/src/compiler/Parser/ParsedHierarchy/IncludedFile.ts
@@ -11,4 +11,8 @@ export class IncludedFile extends ParsedObject {
     // Left to the main story to process
     return null;
   };
+
+  get typeName(): string {
+    return "IncludedFile";
+  }
 }


### PR DESCRIPTION
adds a few extra `typeName`s to classes that lacked them