### PR TITLE
fix: typescript definitions broken

### DIFF
--- a/ink.d.ts
+++ b/ink.d.ts
@@ -1,18 +1,5 @@
-import { Story, InkList } from './engine/Story'
-import { Compiler } from './compiler/Compiler'
-import { CompilerOptions } from './compiler/CompilerOptions'
-import { PosixFileHandler } from './compiler/FileHandler/PosixFileHandler'
-import { JsonFileHandler } from './compiler/FileHandler/JsonFileHandler'
-
-declare interface Inkjs {
-    Story: typeof Story
-    InkList: typeof InkList
-    Compiler: typeof Compiler
-    CompilerOptions: typeof CompilerOptions
-    PosixFileHandler: typeof PosixFileHandler
-    JsonFileHandler: typeof JsonFileHandler
-}
-
-declare let inkjs: Inkjs
-export = inkjs
-export default inkjs
+export { Story, InkList } from "./engine/Story";
+export { Compiler } from "./compiler/Compiler";
+export { CompilerOptions } from "./compiler/CompilerOptions";
+export { PosixFileHandler } from "./compiler/FileHandler/PosixFileHandler";
+export { JsonFileHandler } from "./compiler/FileHandler/JsonFileHandler";


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
<!-- NOTE:
    Running `npm run-script lint:fix` will fix most of the
    linting problems automatically.
-->

## Description

The TypeScript definitions were not working for me. I tried the following variations:

```ts
import * as inkjs from 'inkjs'

let story: inkjs.Story;
```

```
import { Story } from 'inkjs'

let story: Story;
```

In both cases I received the error: `'Story' refers to a value, but is being used as a type here. Did you mean 'typeof Story'?`

I attempted `typeof inkjs.Story` and `typeof Story` but in both cases this caused TypeScript to  not recognized any of the properties and methods of the `Story` class.

With the changes in this PR, both the above methods of importing work. 


