### PR TITLE
fix: correctly handle empty INCLUDEs

### DIFF
--- a/src/compiler/Parser/InkParser.ts
+++ b/src/compiler/Parser/InkParser.ts
@@ -1993,7 +1993,7 @@ export class InkParser extends StringParser {
       this.Error(`Failed to load: '${filename}'.\nError:${err}`);
     }
 
-    if (includedString) {
+    if (includedString != null) {
       const parser: InkParser = new InkParser(
         includedString,
         filename,


### PR DESCRIPTION
## Checklist

<!--
    Thank you for your contribution! Before submitting this PR, please
    make sure that:
-->

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
    - **Quelques warnings mais ils étaient là avant.**
<!-- NOTE:
    Running `npm run-script lint:fix` will fix most of the
    linting problems automatically.
-->

## Description

<!-- Please describe your pull request. -->

This PR fixes a bug in the compiler with empty INCLUDEs.

Example:
```
// main.ink
INCLUDE a.ink
INCLUDE b.ink
{foo}

// a.ink (empty file)

// b.ink
VAR foo = "bar"
```

If you compile it with the inkjs.Compiler and a correctly set-up JsonFileHandler, the story fails at run-time with `Unresolved variable: foo`.
If `a.ink` is not empty (a single space character is enough), everything works as expected.

This bug is caused by a falsy value ("") not taking the correct branch in an if statement `if (includedString)`. This PR fixes that if with a stricter check: `if (includedString != null)`.
