### PR TITLE
Fixed maxInt type check in RANDOM

### DIFF
--- a/src/engine/Story.ts
+++ b/src/engine/Story.ts
@@ -1368,7 +1368,7 @@ export class Story extends InkObject {
               "Invalid value for minimum parameter of RANDOM(min, max)"
             );
 
-          if (maxInt == null || minInt instanceof IntValue === false)
+          if (maxInt == null || maxInt instanceof IntValue === false)
             return this.Error(
               "Invalid value for maximum parameter of RANDOM(min, max)"
             );


### PR DESCRIPTION
Probably a copy-paste error when duplicating the code from `minInt` (a few lines above) for `maxInt`.
The instanceof check should be on maxInt.