### PR TITLE
Remove export assignment from ink.d.ts

### DIFF
--- a/ink.d.ts
+++ b/ink.d.ts
@@ -1,8 +1,8 @@
-import { Story, InkList } from './engine/Story'
-import { Compiler } from './compiler/Compiler'
-import { CompilerOptions } from './compiler/CompilerOptions'
-import { PosixFileHandler } from './compiler/FileHandler/PosixFileHandler'
-import { JsonFileHandler } from './compiler/FileHandler/JsonFileHandler'
+import { Story, InkList } from './src/engine/Story'
+import { Compiler } from './src/compiler/Compiler'
+import { CompilerOptions } from './src/compiler/CompilerOptions'
+import { PosixFileHandler } from './src/compiler/FileHandler/PosixFileHandler'
+import { JsonFileHandler } from './src/compiler/FileHandler/JsonFileHandler'
 
 declare interface Inkjs {
     Story: typeof Story

--- a/ink.d.ts
+++ b/ink.d.ts
@@ -14,5 +14,4 @@ declare interface Inkjs {
 }
 
 declare let inkjs: Inkjs
-export = inkjs
 export default inkjs


### PR DESCRIPTION

## Description

As described in #959, there is an incompatibility between how this declaration file is structured and the expectations of recent TypeScript versions.

Removing the export assignment ensures that only the default symbol is exported.

```
An export assignment cannot be used in a module with other exported elements.
```

Perhaps a better long term solution would be to upgrade the version of TypeScript used in the project. Happy to help with this if I can get a bit of guidance around where to start and managing build tools.

## Checklist

<!--
    Thank you for your contribution! Before submitting this PR, please
    make sure that:
-->

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
<!-- NOTE:
    Running `npm run-script lint:fix` will fix most of the
    linting problems automatically.
-->

