### PR TITLE
Fix imports and add docblocks

### DIFF
--- a/ink.d.ts
+++ b/ink.d.ts
@@ -1,15 +1,39 @@
-import { Story, InkList } from './src/engine/Story'
-import { Compiler } from './src/compiler/Compiler'
-import { CompilerOptions } from './src/compiler/CompilerOptions'
-import { PosixFileHandler } from './src/compiler/FileHandler/PosixFileHandler'
-import { JsonFileHandler } from './src/compiler/FileHandler/JsonFileHandler'
+import { Story, InkList } from './engine/Story'
+import { Compiler } from './compiler/Compiler'
+import { CompilerOptions } from './compiler/CompilerOptions'
+import { PosixFileHandler } from './compiler/FileHandler/PosixFileHandler'
+import { JsonFileHandler } from './compiler/FileHandler/JsonFileHandler'
 
 declare interface Inkjs {
+    /**
+     * A Story is the core class that represents a complete Ink narrative, and
+     * manages runtime evaluation and state.
+     */
     Story: typeof Story
+ 
+    /**
+     * The underlying type for a list item in Ink.
+     */
     InkList: typeof InkList
+
+    /**
+     * Compiles Ink stories from source.
+     */
     Compiler: typeof Compiler
+
+    /**
+     * Metadata options for a compiler pass.
+     */
     CompilerOptions: typeof CompilerOptions
+
+    /**
+     * Resolves and loads Ink sources from a POSIX filesystem.
+     */
     PosixFileHandler: typeof PosixFileHandler
+
+    /**
+     * Resolves and loads Ink sources from a JSON hierarchy.
+     */
     JsonFileHandler: typeof JsonFileHandler
 }
 


### PR DESCRIPTION
## Description

Fixes a problem introduced in #1049 where the relative imports changed to suit standalone references to these files on disk—but overlooked that the tsconfig had `src` already mapped.

## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
