### PR TITLE
Allow playing a json file

### DIFF
--- a/src/engine/ControlCommand.ts
+++ b/src/engine/ControlCommand.ts
@@ -96,7 +96,7 @@ export class ControlCommand extends InkObject {
     return new ControlCommand(ControlCommand.CommandType.EndTag);
   }
   public toString() {
-    return this.commandType.toString();
+    return "ControlCommand " + this.commandType.toString();
   }
 }
 

--- a/src/engine/Void.ts
+++ b/src/engine/Void.ts
@@ -1,3 +1,7 @@
 import { InkObject } from "./Object";
 
-export class Void extends InkObject {}
+export class Void extends InkObject {
+  public toString() {
+    return "Void";
+  }
+}


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

All playing a json file on the command line (was previously limited to playing an uncompiled ink file)