### PR TITLE
Publish es6 as mjs and declare type

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: npm install
       - name: Install codecov

--- a/.github/workflows/npm-manual-publish.yml
+++ b/.github/workflows/npm-manual-publish.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install
       - run: npm run lint
       - run: npm run build
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install
       - run: npm run lint
       - run: npm run build
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm install

--- a/ink.d.mts
+++ b/ink.d.mts
@@ -1,0 +1,41 @@
+import { Story, InkList } from './engine/Story'
+import { Compiler } from './compiler/Compiler'
+import { CompilerOptions } from './compiler/CompilerOptions'
+import { PosixFileHandler } from './compiler/FileHandler/PosixFileHandler'
+import { JsonFileHandler } from './compiler/FileHandler/JsonFileHandler'
+
+declare interface Inkjs {
+    /**
+     * A Story is the core class that represents a complete Ink narrative, and
+     * manages runtime evaluation and state.
+     */
+    Story: typeof Story
+ 
+    /**
+     * The underlying type for a list item in Ink.
+     */
+    InkList: typeof InkList
+
+    /**
+     * Compiles Ink stories from source.
+     */
+    Compiler: typeof Compiler
+
+    /**
+     * Metadata options for a compiler pass.
+     */
+    CompilerOptions: typeof CompilerOptions
+
+    /**
+     * Resolves and loads Ink sources from a POSIX filesystem.
+     */
+    PosixFileHandler: typeof PosixFileHandler
+
+    /**
+     * Resolves and loads Ink sources from a JSON hierarchy.
+     */
+    JsonFileHandler: typeof JsonFileHandler
+}
+
+declare let inkjs: Inkjs
+export default inkjs

--- a/package.json
+++ b/package.json
@@ -4,9 +4,20 @@
   "description": "A javascript port of inkle's ink scripting language (http://www.inklestudios.com/ink/)",
   "type": "commonjs",
   "main": "dist/ink-full.js",
-  "module": "dist/ink-full.mjs",
   "types": "ink.d.ts",
-  "files": ["src/engine","src/compiler","ink.d.ts","script/inkjs-compiler.ts"],
+  "files": ["src/engine","src/compiler","ink.d.ts", "ink.d.mts","script/inkjs-compiler.ts", "dist"],
+  "exports": {
+    ".":{
+      "types": "./ink.d.mts",
+      "import": "./dist/ink.mjs",
+      "default": "./dist/ink.js"
+    },
+    "./full":{
+      "types": "./ink.d.mts",
+      "import": "./dist/ink-full.mjs",
+      "default": "./dist/ink-full.js"
+    }
+  },
   "scripts": {
     "test": "npm run test:typescript && npm run test:javascript",
     "test:typescript": "jest",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "inkjs",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A javascript port of inkle's ink scripting language (http://www.inklestudios.com/ink/)",
+  "type": "commonjs",
   "main": "dist/ink-full.js",
+  "module": "dist/ink-full.mjs",
   "types": "ink.d.ts",
+  "files": ["src/engine","src/compiler","ink.d.ts","script/inkjs-compiler.ts"],
   "scripts": {
     "test": "npm run test:typescript && npm run test:javascript",
     "test:typescript": "jest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,27 @@ export default [
     input: engineOnlyInputFile,
     output: {
       name: moduleName,
-      file: 'dist/ink-es6.js',
+      file: 'dist/ink.mjs',
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [
+      nodeResolve(),
+      typescript(tsconfig),
+      babel({
+        exclude: 'node_modules/**',
+        extensions: ['.js', '.ts'],
+        babelHelpers: 'bundled'
+      }),
+      terser(),
+      sourcemaps()
+    ]
+  },
+  {
+    input: fullfeatureInputFile,
+    output: {
+      name: moduleName,
+      file: 'dist/ink-full.mjs',
       format: 'es',
       sourcemap: true
     },


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).

## Description

- Publish es6 package with mjs extension
-  fix errors in package.json declared on [publint](https://publint.dev/inkjs@2.2.3) 
    - declare type "commonjs" 
    - add `exports` with `import` and `default` version
- Upgrade github pipeline to Node20

