### PR TITLE
Fixed arguments error reporting

### DIFF
--- a/src/engine/StoryState.ts
+++ b/src/engine/StoryState.ts
@@ -1134,10 +1134,10 @@ export class StoryState {
         ) {
           throw new Error(
             "ink arguments when calling EvaluateFunction / ChoosePathStringWithParameters must be" +
-            "number, string, bool or InkList. Argument was " +
-            (nullIfUndefined(arguments[i]) === null)
-              ? "null"
-              : arguments[i].constructor.name
+              "number, string, bool or InkList. Argument was " +
+              (nullIfUndefined(args[i]) === null
+                ? "null"
+                : args[i].constructor.name)
           );
         }
 

--- a/src/tests/specs/inkjs/engine/Integration.spec.ts
+++ b/src/tests/specs/inkjs/engine/Integration.spec.ts
@@ -175,6 +175,22 @@ describe("Integration", () => {
     expect(context.story.EvaluateFunction("fn_echo", [5.3])).toEqual(5.3);
   });
 
+  it("should report invalid params passed to ink functions", () => {
+    class BadParameter {}
+    expect(() =>
+      context.story.EvaluateFunction("fn_params", [new BadParameter()])
+    ).toThrow("Argument was BadParameter");
+  });
+
+  it("should report invalid params passed to knots/stitches", () => {
+    class BadParameter {}
+    expect(() =>
+      context.story.ChoosePathString("stitch_with_param", undefined, [
+        new BadParameter(),
+      ])
+    ).toThrow("Argument was BadParameter");
+  });
+
   it("should return output and return value from ink function calls", () => {
     expect(context.story.EvaluateFunction("fn_print", [], true)).toEqual({
       output: "function called\n",


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
(there were pre-existing warnings)

## Description

`PassArgumentsToEvaluationStack` checks that arguments are valid and reports an error if not.
There are two bugs in this function:
- the arguments to validate are in the `args` variable but this function incorrectly uses the special `arguments` keyword instead in two places in the error reporting section
- the ternary operator is incorrectly parenthesised, causing the thrown error to always be `new Error("null")`

I've added two tests to check that an invalid parameter passed to a function or a knot/stitch is correctly reported.

