### PR TITLE
list global variables using Object.keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10554,6 +10554,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/src/engine/VariablesState.ts
+++ b/src/engine/VariablesState.ts
@@ -155,6 +155,22 @@ export class VariablesState extends VariablesStateAccessor<
           else target.$(name, value);
           return true; // returning a falsy value make the trap fail
         },
+        ownKeys(target: any) {
+          return [
+            ...new Set([
+              ...target._defaultGlobalVariables.keys(),
+              ...target._globalVariables.keys(),
+            ]),
+          ];
+        },
+        getOwnPropertyDescriptor(target, name) {
+          // called for every property
+          return {
+            enumerable: true,
+            configurable: true,
+            value: target.$(name),
+          };
+        },
       });
 
       return p;

--- a/src/tests/specs/ink/Bindings.spec.ts
+++ b/src/tests/specs/ink/Bindings.spec.ts
@@ -135,4 +135,13 @@ describe("Bindings", () => {
     context.story.BindExternalFunction("myAction", () => {});
     expect(context.story.ContinueMaximally()).toBe("One\nTwo\n");
   });
+
+  it("is possible to list all GlobalVariables using Object.keys", () => {
+    compileStory("variable_observer");
+
+    expect(Object.keys(context.story.variablesState)).toStrictEqual([
+      "testVar",
+      "testVar2",
+    ]);
+  });
 });


### PR DESCRIPTION
## Checklist

- [ ] The new code additions passed the tests (`npm test`).
- [ ] The linter ran and found no issues (`npm run-script lint`).

## Description
https://github.com/y-lohse/inkjs/issues/1058

You can now list all global variables (`VAR` and `LIST`) using `Object.keys(story.variableState)`
