### PR TITLE
Prefix -> in front of divertTarget when using EvaluateFunction

### DIFF
--- a/src/engine/StoryState.ts
+++ b/src/engine/StoryState.ts
@@ -1218,7 +1218,7 @@ export class StoryState {
       // DivertTargets get returned as the string of components
       // (rather than a Path, which isn't public)
       if (returnVal.valueType == ValueType.DivertTarget) {
-        return returnVal.valueObject.toString();
+        return "-> " + returnVal.valueObject.toString();
       }
 
       // Other types can just have their exact object type:

--- a/src/tests/specs/ink/Evaluation.spec.ts
+++ b/src/tests/specs/ink/Evaluation.spec.ts
@@ -57,7 +57,7 @@ describe("Evaluation", () => {
 
     let returnedDivertTarget = context.story.EvaluateFunction("test");
 
-    expect(returnedDivertTarget).toBe("somewhere.here");
+    expect(returnedDivertTarget).toBe("-> somewhere.here");
   });
 
   // TestEvaluatingInkFunctionsFromGame2


### PR DESCRIPTION
## Checklist
- [ ] The new code additions passed the tests (`npm test`).
- [ ] The linter ran and found no issues (`npm run-script lint`).

## Description
https://github.com/y-lohse/inkjs/issues/1099

`Path` is not a publicly exposed class in js. So I suggest we prefix any DivertTarget with a `-> `