### PR TITLE
feat: compiler: add source filename to the IFileHandler

### DIFF
--- a/src/compiler/IFileHandler.ts
+++ b/src/compiler/IFileHandler.ts
@@ -1,6 +1,12 @@
 export interface IFileHandler {
-  readonly ResolveInkFilename: (filename: string) => string;
-  readonly LoadInkFileContents: (filename: string) => string;
+  readonly ResolveInkFilename: (
+    filename: string,
+    sourceFilename?: string | null
+  ) => string;
+  readonly LoadInkFileContents: (
+    filename: string,
+    sourceFilename?: string | null
+  ) => string;
 }
 
 // Looking for DefaultFileHandler? POSIXFileHandler replaces it in inkjs.

--- a/src/compiler/Parser/InkParser.ts
+++ b/src/compiler/Parser/InkParser.ts
@@ -1988,7 +1988,10 @@ export class InkParser extends StringParser {
     filename = filename.replace(new RegExp(/[ \t]+$/g), "");
 
     // Working directory should already have been set up relative to the root ink file.
-    const fullFilename = this.fileHandler.ResolveInkFilename(filename);
+    const fullFilename = this.fileHandler.ResolveInkFilename(
+      filename,
+      this._filename
+    );
 
     if (this.FilenameIsAlreadyOpen(fullFilename)) {
       this.Error(
@@ -2003,8 +2006,10 @@ export class InkParser extends StringParser {
     let includedStory: Story | null = null;
     let includedString: string = "";
     try {
-      includedString =
-        this._rootParser.fileHandler.LoadInkFileContents(fullFilename);
+      includedString = this._rootParser.fileHandler.LoadInkFileContents(
+        fullFilename,
+        this._filename
+      );
     } catch (err) {
       this.Error(`Failed to load: '${filename}'.\nError:${err}`);
     }


### PR DESCRIPTION
## Checklist

<!--
    Thank you for your contribution! Before submitting this PR, please
    make sure that:
-->

- [x] The new code additions passed the tests (`npm test`).
- [x] The linter ran and found no issues (`npm run-script lint`).
<!-- NOTE:
    Running `npm run-script lint:fix` will fix most of the
    linting problems automatically.
-->

## Description

Add a `sourceFilename` parameter to the `ResolveInkFilename` and `LoadInkFileContents` methods of the `IFileHandler`. These will provide context to the IFileHandler to be able to resolve the actual Include Filename, relative to the Source Ink Filename that included it. This is particularly useful when an Ink Story has Include Files that, in themselves, also Include Files.

For example, `/main.ink` includes `/common/functions.ink`, which includes `/common/library/my_function.ink`, this would open the door to define as follows:

```/main.ink
INCLUDE common/functions.ink
```

```/common/functions.ink
INCLUDE library/my_functions.ink
```

This PR is being proposed in support of a [VSCode Extension for Ink](https://github.com/bemisguided/vscode-ink-language-tools) under-development.

On Discord, we discussed concerns about breaking compatibility with Inky, which this most certainly open the door for. It was agreed that the VSCode Extension should offer an "Inky compatibility" setting (default to enabled), to avoid confusion, when using this new feature.

<!-- Please describe your pull request. -->
